### PR TITLE
Allow dynamic outage messages from JSON

### DIFF
--- a/assets/template.html
+++ b/assets/template.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom maintenance page</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="text-center grid place-items-center h-screen">
+  <div>
+  <h1 class="text-3xl font-bold mb-2">
+    %s
+  </h1>
+  <p>%s</p>
+  </div>
+</body>
+</html>

--- a/maintenance.go
+++ b/maintenance.go
@@ -1,210 +1,218 @@
 package traefik_maintenance_plugin
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"log"
-	"mime"
-	"net"
-	"net/http"
-	"regexp"
-	"strings"
-	"time"
+  "bytes"
+  "context"
+  "encoding/json"
+  "fmt"
+  "log"
+  "mime"
+  "net"
+  "net/http"
+  "os"
+  "regexp"
+  "strings"
+  "time"
 )
 
 type Config struct {
-	InformUrl      string        `yaml:"informUrl"`
-	InformInterval time.Duration `yaml:"informInterval"`
-	InformTimeout  time.Duration `yaml:"informTimeout"`
+  InformUrl      string        `yaml:"informUrl"`
+  InformInterval time.Duration `yaml:"informInterval"`
+  InformTimeout  time.Duration `yaml:"informTimeout"`
+  BaseTemplatePath string      `yaml:"baseTemplatePath"`
 }
 
 type Host struct {
-	Regex    string
-	AllowIps []string
+  Regex    string
+  AllowIps []string
+  Template string
+  Heading  string
+  Message  string
 }
 
 type Maintenance struct {
-	name   string
-	next   http.Handler
-	config *Config
+  name   string
+  next   http.Handler
+  config *Config
 }
 
 type ResponseWriter struct {
-	buffer bytes.Buffer
+  buffer bytes.Buffer
 
-	http.ResponseWriter
+  http.ResponseWriter
 }
 
 // Global variables
 var hosts []Host
 
 func CreateConfig() *Config {
-	return &Config{
-		InformInterval: 60,
-		InformTimeout:  5,
-	}
+  return &Config{
+    InformInterval: 60,
+    InformTimeout:  5,
+  }
 }
 
 // Inform if there are hosts in maintenance
 func Inform(config *Config) {
-	t := time.NewTicker(time.Second * config.InformInterval)
-	defer t.Stop()
+  t := time.NewTicker(time.Second * config.InformInterval)
+  defer t.Stop()
 
-	for ; true; <-t.C {
-		client := http.Client{
-			Timeout: time.Second * config.InformTimeout,
-		}
+  for ; true; <-t.C {
+    client := http.Client{
+      Timeout: time.Second * config.InformTimeout,
+    }
 
-		req, _ := http.NewRequest(http.MethodGet, config.InformUrl, nil)
-		res, doErr := client.Do(req)
-		if doErr != nil {
-			log.Printf("Inform: %v", doErr) // Don't fatal, just go further
-			continue
-		}
+    req, _ := http.NewRequest(http.MethodGet, config.InformUrl, nil)
+    res, doErr := client.Do(req)
+    if doErr != nil {
+      log.Printf("Inform: %v", doErr) // Don't fatal, just go further
+      continue
+    }
 
-		defer res.Body.Close()
+    defer res.Body.Close()
 
-		decoder := json.NewDecoder(res.Body)
-		decodeErr := decoder.Decode(&hosts)
-		if decodeErr != nil {
-			log.Printf("Inform: %v", decodeErr) // Don't fatal, just go further
-			continue
-		}
+    decoder := json.NewDecoder(res.Body)
+    decodeErr := decoder.Decode(&hosts)
+    if decodeErr != nil {
+      log.Printf("Inform: %v", decodeErr) // Don't fatal, just go further
+      continue
+    }
 
-		log.Printf("Inform response: %v", hosts)
-	}
+    for i, host := range hosts {
+      hosts[i].Template = config.BaseTemplatePath + host.Template
+    }
+
+    log.Printf("Inform response: %v", hosts)
+  }
 }
 
 // Get all the client's ips
 func GetClientIps(req *http.Request) []string {
-	var ips []string
+  var ips []string
 
-	if req.RemoteAddr != "" {
-		ip, _, splitErr := net.SplitHostPort(req.RemoteAddr)
-		if splitErr != nil {
-			ip = req.RemoteAddr
-		}
-		ips = append(ips, ip)
-	}
+  if req.RemoteAddr != "" {
+    ip, _, splitErr := net.SplitHostPort(req.RemoteAddr)
+    if splitErr != nil {
+      ip = req.RemoteAddr
+    }
+    ips = append(ips, ip)
+  }
 
-	forwardedFor := req.Header.Get("X-Forwarded-For")
-	if forwardedFor != "" {
-		for _, ip := range strings.Split(forwardedFor, ",") {
-			ips = append(ips, strings.TrimSpace(ip))
-		}
-	}
+  forwardedFor := req.Header.Get("X-Forwarded-For")
+  if forwardedFor != "" {
+    for _, ip := range strings.Split(forwardedFor, ",") {
+      ips = append(ips, strings.TrimSpace(ip))
+    }
+  }
 
-	return ips
+  return ips
 }
 
 // Check if one of the client ips has access
 func CheckIpAllowed(req *http.Request, host Host) bool {
-	for _, ip := range GetClientIps(req) {
-		for _, allowIp := range host.AllowIps {
-			if ip == allowIp {
-				return true
-			}
-		}
-	}
+  for _, ip := range GetClientIps(req) {
+    for _, allowIp := range host.AllowIps {
+      if ip == allowIp {
+        return true
+      }
+    }
+  }
 
-	return false
+  return false
 }
 
 // Check if the host is under maintenance
 func CheckIfMaintenance(req *http.Request) bool {
-	for _, host := range hosts {
-		if matched, _ := regexp.Match(host.Regex, []byte(req.Host)); matched {
-			return !CheckIpAllowed(req, host)
-		}
-	}
+  for _, host := range hosts {
+    if matched, _ := regexp.Match(host.Regex, []byte(req.Host)); matched {
+      return !CheckIpAllowed(req, host)
+    }
+  }
 
-	return false
+  return false
+}
+
+func GetHost(req *http.Request) Host {
+  for _, host := range hosts {
+    if matched, _ := regexp.Match(host.Regex, []byte(req.Host)); matched {
+      return host
+    }
+  }
+  return Host{}
 }
 
 func (rw *ResponseWriter) Header() http.Header {
-	return rw.ResponseWriter.Header()
+  return rw.ResponseWriter.Header()
 }
 
 func (rw *ResponseWriter) Write(bytes []byte) (int, error) {
-	return rw.buffer.Write(bytes)
+  return rw.buffer.Write(bytes)
 }
 
 func (rw *ResponseWriter) WriteHeader(statusCode int) {
-	rw.ResponseWriter.Header().Del("Last-Modified")
-	rw.ResponseWriter.Header().Del("Content-Length")
+  rw.ResponseWriter.Header().Del("Last-Modified")
+  rw.ResponseWriter.Header().Del("Content-Length")
 
-	rw.ResponseWriter.WriteHeader(http.StatusServiceUnavailable)
+  rw.ResponseWriter.WriteHeader(http.StatusServiceUnavailable)
 }
 
 func New(_ context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
-	go Inform(config)
+  go Inform(config)
 
-	return &Maintenance{
-		name:   name,
-		next:   next,
-		config: config,
-	}, nil
+  return &Maintenance{
+    name:   name,
+    next:   next,
+    config: config,
+  }, nil
 }
 
 func (a *Maintenance) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
-	if CheckIfMaintenance(req) {
-		wrappedWriter := &ResponseWriter{
-			ResponseWriter: rw,
-		}
+  if CheckIfMaintenance(req) {
+    wrappedWriter := &ResponseWriter{
+      ResponseWriter: rw,
+    }
 
-		a.next.ServeHTTP(wrappedWriter, req)
+    a.next.ServeHTTP(wrappedWriter, req)
 
-		bytes := []byte{}
+    bytes := []byte{}
 
-		contentType := wrappedWriter.Header().Get("Content-Type")
-		if contentType != "" {
-			mt, _, _ := mime.ParseMediaType(contentType)
-			bytes = getTemplate(mt)
-		}
+    contentType := wrappedWriter.Header().Get("Content-Type")
+    if contentType != "" {
+      mt, _, _ := mime.ParseMediaType(contentType)
+      host := GetHost(req)
+      bytes = getTemplate(mt, host)
+    }
 
-		rw.Write(bytes)
+    rw.Write(bytes)
 
-		if flusher, ok := rw.(http.Flusher); ok {
-			flusher.Flush()
-		}
+    if flusher, ok := rw.(http.Flusher); ok {
+      flusher.Flush()
+    }
 
-		return
-	}
+    return
+  }
 
-	a.next.ServeHTTP(rw, req)
+  a.next.ServeHTTP(rw, req)
 }
 
 // Maintenance page templates
-func getTemplate(mediaType string) []byte {
-	switch mediaType {
+func getTemplate(mediaType string, host Host) []byte {
+  switch mediaType {
 
-	case "text/html":
-		return []byte(`<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Under maintenance</title>
-	<script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="text-center grid place-items-center h-screen">
-	<div>
-	<h1 class="text-3xl font-bold mb-2">
-		This page is under maintenance
-	</h1>
-	<p>Please come back later.</p>
-	</div>
-</body>
-</html>`)
+  case "text/html":
+    dat, err := os.ReadFile(host.Template)
+    if err != nil {
+      log.Printf("Template read error: %v", err)
+    }
+    return []byte(fmt.Sprintf(string(dat),host.Heading,host.Message))
 
-	case "text/plain":
-		return []byte("This page is under maintenance. Please come back later.")
+  case "text/plain":
+    return []byte(host.Heading + host.Message)
 
-	case "application/json":
-		return []byte("{\"message\": \"This page is under maintenance. Please come back later.\"}")
-	}
+  case "application/json":
+    return []byte("{\"message\": \"" + host.Heading + host.Message + "\"}")
+  }
 
-	return []byte{}
+  return []byte{}
 }

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     networks:
       - web
     volumes:
+      - ../assets:/assets
       - /var/run/docker.sock:/var/run/docker.sock
       - ./services/traefik/dynamic:/etc/traefik/dynamic
       - ./services/traefik/traefik.yml:/etc/traefik/traefik.yml

--- a/test/services/inform/inform.json
+++ b/test/services/inform/inform.json
@@ -3,12 +3,18 @@
     "regex": "maintenance.test",
     "allowIps": [
       "172.18.0.1"
-    ]
-  }, 
+    ],
+    "template": "template.html",
+    "heading": "This page is under custom maintenance",
+    "message": "Please come back later when we have fixed it"
+  },
   {
     "regex": "app.maintenance.test",
     "allowIps": [
       "172.18.0.1"
-    ]
+    ],
+    "template": "template.html",
+    "heading": "This page is under custom maintenance",
+    "message": "Please come back later when we have fixed it"
   }
 ]

--- a/test/services/traefik/dynamic/middleware.yml
+++ b/test/services/traefik/dynamic/middleware.yml
@@ -6,3 +6,4 @@ http:
           informUrl: "http://inform/inform.json"
           informInterval: 5
           informTimeout: 3
+          baseTemplatePath: "/assets/"


### PR DESCRIPTION
*This is a breaking change*

This change allows for customization of the maintenance message on a host-by-host basis.  It does this by adding new values to the `inform` json, and adding a new configuration value.

The new architecture assumes that there is a directory (communicated via configuration) that contains the template files that will be served. When it loads the `inform` json, it also expects that the json will contain a `template` value that, when appended to the base configuration directory, will give the location of a template file to display when the service is in maintenance mode.

The json should also include a `header` and `message` value.  These values will be used to control the message returned when maintenance mode is enabled. The template file should also have two `%s` symbols inside so that the header and message text can be included in the final message.